### PR TITLE
Require a token to read crash reports

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,1 +1,1 @@
-{"port": 6000, "crash_dir": "/tmp/crashes/"}
+{"port": 6000, "crash_dir": "/tmp/crashes/", "read_secret": "xxx", "write_secret", "xxx"}

--- a/crash_reporter/flask_server.py
+++ b/crash_reporter/flask_server.py
@@ -1,15 +1,25 @@
 from datetime import datetime
-from flask import Flask, request, send_file
+from flask import Flask, request, send_file, abort
+from flask_httpauth import HTTPBasicAuth
 from os import listdir
 from os.path import exists, isfile, join
 import json
-app = Flask(__name__)
 
-crash_dir = None
+app = Flask(__name__)
+auth = HTTPBasicAuth()
+
+@auth.verify_password
+def verify_password(username, password):
+    if password == config['read_secret']:
+        return "valid_user"
 
 @app.route("/report", methods=["POST"])
 def report():
     report = request.get_json()
+    if 'secret' not in report or report['secret'] != config['write_secret']:
+        abort(403)
+        return
+    del report['secret']
     id = 0
     idstr = None
     now = datetime.now()
@@ -18,7 +28,7 @@ def report():
     while True:
       idstr = str(id).zfill(4)
       filename = 'crash-' + date + "-" +  idstr + '.json'
-      crashfile = join(crash_dir, filename)
+      crashfile = join(config['crash_dir'], filename)
       try:
           fd = open(crashfile, 'x')
           json.dump(report, fd, indent=2)
@@ -30,6 +40,7 @@ def report():
 
 @app.route("/list", methods=["GET"])
 def list():
+    crash_dir = config['crash_dir']
     crash_files = [f for f in listdir(crash_dir) if isfile(join(crash_dir, f)) and f.startswith("crash-")]
     crash_ids = map(lambda f: f.replace("crash-","").replace(".json", ""), crash_files)
     lis = map(lambda i: '<li><a href="./query?id=' + i + '">' + i + '</a></li>', crash_ids)
@@ -37,21 +48,25 @@ def list():
     return (html, 200)
 
 @app.route("/query", methods=["GET"])
+@auth.login_required
 def query():
     if 'id' in request.args:
         id = request.args['id']
         filename = 'crash-' + id + '.json'
-        crashfile = join(crash_dir, filename)
-        return send_file(crashfile)
-    return ('', 404)
+        crashfile = join(config['crash_dir'], filename)
+        if exists(crashfile):
+          return send_file(crashfile)
+        return ('Report not found', 404)
+    return ('Missing ID', 400)
 
 def main():
+    global config
     with open('config.json') as f:
         config = json.loads(f.read())
         assert('port' in config)
         assert('crash_dir' in config)
-        global crash_dir
-        crash_dir = config['crash_dir']
+        assert('read_secret' in config)
+        assert('write_secret' in config)
     app.run(port=config['port'])
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     packages=['crash_reporter'],
     install_requires=[
         'flask',
+        'Flask-HTTPAuth',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Fix #1 

This requires something like:

```
curl -H "Authorization: Bearer foobar" 'http://127.0.0.1:6000/query?id=2020-08-05-000004'
```

… to retrieve the log. Which might not be very simple to use.

@jdm would you rather see a Basic or digest auth?